### PR TITLE
Flag loader as cachable

### DIFF
--- a/src/to-string.js
+++ b/src/to-string.js
@@ -2,5 +2,6 @@
  * @see https://github.com/webpack/webpack/wiki/Loader-Specification
  */
 module.exports = function (content) {
+    this.cacheable();
     return 'module.exports = ' + JSON.stringify(this.exec(content, this.resource).toString());
 };


### PR DESCRIPTION
Hi,

guided by https://webpack.github.io/docs/how-to-write-a-loader.html loader should be marked as cachable when its possible.